### PR TITLE
Strongly typed PerFieldAnalyzerWrapper.AddAnalyzer extension method

### DIFF
--- a/Lucene.Net.Linq.Tests/Integration/SelectTests.cs
+++ b/Lucene.Net.Linq.Tests/Integration/SelectTests.cs
@@ -14,8 +14,8 @@ namespace Lucene.Net.Linq.Tests.Integration
         protected override Analyzer GetAnalyzer(Net.Util.Version version)
         {
             analyzer = new PerFieldAnalyzerWrapper(base.GetAnalyzer(version));
-            analyzer.AddAnalyzer("Id", new KeywordAnalyzer());
-            analyzer.AddAnalyzer("Key", new LowercaseKeywordAnalyzer());
+            analyzer.AddAnalyzer<SampleDocument>(t => t.Id, new KeywordAnalyzer());
+            analyzer.AddAnalyzer<SampleDocument>(t => t.Key, new LowercaseKeywordAnalyzer());
             return analyzer;
         }
 
@@ -204,7 +204,7 @@ namespace Lucene.Net.Linq.Tests.Integration
         [Test]
         public void Where_ExactMatch_CaseInsensitive()
         {
-            analyzer.AddAnalyzer("Id", new LowercaseKeywordAnalyzer());
+            analyzer.AddAnalyzer<SampleDocument>(t => t.Id, new LowercaseKeywordAnalyzer());
             AddDocument(new SampleDocument { Name = "Other Document", Key = "X.Y.1.2" });
             AddDocument(new SampleDocument { Name = "My Document", Key = "X.Z.1.3" });
 
@@ -218,7 +218,7 @@ namespace Lucene.Net.Linq.Tests.Integration
         [Test]
         public void Where_IgnoresToLower()
         {
-            analyzer.AddAnalyzer("Id", new LowercaseKeywordAnalyzer());
+            analyzer.AddAnalyzer<SampleDocument>(t => t.Id, new LowercaseKeywordAnalyzer());
             AddDocument(new SampleDocument { Name = "Other Document", Key = "X.Y.1.2" });
             AddDocument(new SampleDocument { Name = "My Document", Key = "X.Z.1.3" });
 
@@ -232,7 +232,7 @@ namespace Lucene.Net.Linq.Tests.Integration
         [Test]
         public void Where_IgnoresToLowerWithinNullSafetyCondition()
         {
-            analyzer.AddAnalyzer("Id", new LowercaseKeywordAnalyzer());
+            analyzer.AddAnalyzer<SampleDocument>(t => t.Id, new LowercaseKeywordAnalyzer());
             AddDocument(new SampleDocument { Name = "Other Document", Key = "X.Y.1.2" });
             AddDocument(new SampleDocument { Name = "My Document", Key = "X.Z.1.3" });
 
@@ -259,7 +259,7 @@ namespace Lucene.Net.Linq.Tests.Integration
         [Test]
         public void Where_LowercaseKeyword_StartsWith()
         {
-            analyzer.AddAnalyzer("Id", new LowercaseKeywordAnalyzer());
+            analyzer.AddAnalyzer<SampleDocument>(t => t.Id, new LowercaseKeywordAnalyzer());
             AddDocument(new SampleDocument { Name = "Other Document", Key = "X.Y.1.2" });
             AddDocument(new SampleDocument { Name = "My Document", Key = "X.Z.1.3" });
 

--- a/Lucene.Net.Linq/AnalyzerExtensions.cs
+++ b/Lucene.Net.Linq/AnalyzerExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using Lucene.Net.Analysis;
+using Remotion.Linq.Utilities;
+
+namespace Lucene.Net.Linq
+{
+    /// <summary>
+    /// Provides extensions to built in Lucene.Net Analyzer classes
+    /// </summary>
+    public static class AnalyzerExtensions
+    {
+        /// <summary>
+        /// Defines an analyzer to use for the specified field in a strongly typed manner
+        /// </summary>
+        /// <typeparam name="TDocument">Type of the stored Lucene document</typeparam>
+        /// <param name="this"></param>
+        /// <param name="fieldName">field name requiring a non-default analyzer as a member expression</param>
+        /// <param name="analyzer">non-default analyzer to use for field</param>
+        public static void AddAnalyzer<TDocument>(this PerFieldAnalyzerWrapper @this, Expression<Func<TDocument, object>> fieldName, Analyzer analyzer)
+        {
+            try
+            {
+                @this.AddAnalyzer(((MemberExpression)fieldName.Body).Member.Name, analyzer);
+            }
+            catch (Exception ex)
+            {
+                throw new ArgumentException("Field name must be specified as a lambda to a member property, ex. doc => doc.FirstName", ex);
+            }
+        }
+    }
+}

--- a/Lucene.Net.Linq/Lucene.Net.Linq.csproj
+++ b/Lucene.Net.Linq/Lucene.Net.Linq.csproj
@@ -63,6 +63,7 @@
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
     <Compile Include="Abstractions\IIndexWriter.cs" />
+    <Compile Include="AnalyzerExtensions.cs" />
     <Compile Include="Clauses\ExpressionNodes\BoostExpressionNode.cs" />
     <Compile Include="Clauses\BoostClause.cs" />
     <Compile Include="Clauses\ExpressionNodes\TrackRetrievedDocumentsExpressionNode.cs" />


### PR DESCRIPTION
I think this should help continue the strong typing across the library in the instance where you need to specify a custom analyzer (especially for  [Field(IndexMode.NotAnalyzed)] fields). Down with the magic strings! What do you think?
