### PR TITLE
Fixes bug when query field and constant are switched and operator is not

### DIFF
--- a/Lucene.Net.Linq.Tests/Transformation/TreeVisitors/BinaryToQueryExpressionTreeVisitorTests.cs
+++ b/Lucene.Net.Linq.Tests/Transformation/TreeVisitors/BinaryToQueryExpressionTreeVisitorTests.cs
@@ -28,6 +28,46 @@ namespace Lucene.Net.Linq.Tests.Transformation.TreeVisitors
         }
 
         [Test]
+        public void GreaterThan_SwitchesOperatorWhenConstantIsOnLeft()
+        {
+            var five = Expression.Constant(5);
+            var expression = Expression.MakeBinary(ExpressionType.GreaterThan, five, new LuceneQueryFieldExpression(typeof(int), "Count"));
+
+            var result = visitor.VisitExpression(expression);
+            AssertLuceneQueryExpression(result, "Count", five, QueryType.LessThan, Occur.MUST);
+        }
+
+        [Test]
+        public void LessThan_SwitchesOperatorWhenConstantIsOnLeft()
+        {
+            var five = Expression.Constant(5);
+            var expression = Expression.MakeBinary(ExpressionType.LessThan, five, new LuceneQueryFieldExpression(typeof(int), "Count"));
+
+            var result = visitor.VisitExpression(expression);
+            AssertLuceneQueryExpression(result, "Count", five, QueryType.GreaterThan, Occur.MUST);
+        }
+
+        [Test]
+        public void GreaterThanOrEqual_SwitchesOperatorWhenConstantIsOnLeft()
+        {
+            var five = Expression.Constant(5);
+            var expression = Expression.MakeBinary(ExpressionType.GreaterThanOrEqual, five, new LuceneQueryFieldExpression(typeof(int), "Count"));
+
+            var result = visitor.VisitExpression(expression);
+            AssertLuceneQueryExpression(result, "Count", five, QueryType.LessThanOrEqual, Occur.MUST);
+        }
+
+        [Test]
+        public void LessThanOrEqual_SwitchesOperatorWhenConstantIsOnLeft()
+        {
+            var five = Expression.Constant(5);
+            var expression = Expression.MakeBinary(ExpressionType.LessThanOrEqual, five, new LuceneQueryFieldExpression(typeof(int), "Count"));
+
+            var result = visitor.VisitExpression(expression);
+            AssertLuceneQueryExpression(result, "Count", five, QueryType.GreaterThanOrEqual, Occur.MUST);
+        }
+
+        [Test]
         public void Equal()
         {
             var foo = Expression.Constant("foo");
@@ -56,7 +96,7 @@ namespace Lucene.Net.Linq.Tests.Transformation.TreeVisitors
             var result = visitor.VisitExpression(expression);
             AssertLuceneQueryExpression(result, "Count", five, QueryType.GreaterThan, Occur.MUST);
         }
-
+        
         [Test]
         public void GreaterThanOrEqual()
         {

--- a/Lucene.Net.Linq/Transformation/TreeVisitors/BinaryToQueryExpressionTreeVisitor.cs
+++ b/Lucene.Net.Linq/Transformation/TreeVisitors/BinaryToQueryExpressionTreeVisitor.cs
@@ -36,6 +36,22 @@ namespace Lucene.Net.Linq.Transformation.TreeVisitors
             {
                 fieldExpression = (LuceneQueryFieldExpression) expression.Right;
                 pattern = expression.Left;
+
+                switch(queryType)
+                {
+                    case QueryType.GreaterThan:
+                        queryType = QueryType.LessThan;
+                        break;
+                    case QueryType.LessThan:
+                        queryType = QueryType.GreaterThan;
+                        break;
+                    case QueryType.GreaterThanOrEqual:
+                        queryType = QueryType.LessThanOrEqual;
+                        break;
+                    case QueryType.LessThanOrEqual:
+                        queryType = QueryType.GreaterThanOrEqual;
+                        break;
+                }
             }
             else
             {


### PR DESCRIPTION
I found a bug when you have a query like this:
var query = from a in Articles
                     where 5 >= a.Id
                     select a;

This query was being effectively turned into this:
var query = from a in Articles
                     where a.Id >= 5
                     select a;

but without switching the operator from >= to <= to keep the original meaning of the where clause.  I fixed this in the BinaryToQueryExpressionTreeVisitor and added tests for it in BinaryToQueryExpressionTreeVisitorTests.
