### PR TITLE
Add Lucene Document parameter to factory Func 

### DIFF
--- a/source/Lucene.Net.Linq/LuceneDataProvider.cs
+++ b/source/Lucene.Net.Linq/LuceneDataProvider.cs
@@ -99,7 +99,7 @@ namespace Lucene.Net.Linq
         /// </summary>
         public IQueryable<T> AsQueryable<T>() where T : new()
         {
-            return AsQueryable(() => new T());
+            return AsQueryable((d) => new T());
         }
 
         /// <summary>
@@ -107,13 +107,13 @@ namespace Lucene.Net.Linq
         /// </summary>
         public IQueryable<T> AsQueryable<T>(IDocumentMapper<T> documentMapper) where T : new()
         {
-            return AsQueryable(() => new T(), documentMapper);
+            return AsQueryable((d) => new T(), documentMapper);
         }
 
         /// <summary>
         /// <see cref="AsQueryable{T}(System.Func{T}, IDocumentMapper{T})"/>
         /// </summary>
-        public IQueryable<T> AsQueryable<T>(Func<T> factory)
+        public IQueryable<T> AsQueryable<T>(Func<Document, T> factory)
         {
             return AsQueryable(factory, new ReflectionDocumentMapper<T>(version, externalAnalyzer));
         }
@@ -125,7 +125,7 @@ namespace Lucene.Net.Linq
         /// <typeparam name="T">The type of object that Document will be mapped onto.</typeparam>
         /// <param name="factory">Factory method to instantiate new instances of T.</param>
         /// <param name="documentMapper">Mapper that will convert documents to objects and vice versa.</param>
-        public IQueryable<T> AsQueryable<T>(Func<T> factory, IDocumentMapper<T> documentMapper)
+        public IQueryable<T> AsQueryable<T>(Func<Document, T> factory, IDocumentMapper<T> documentMapper)
         {
             return CreateQueryable(factory, context, documentMapper);
         }
@@ -135,7 +135,7 @@ namespace Lucene.Net.Linq
         /// </summary>
         public ISession<T> OpenSession<T>() where T : new()
         {
-            return OpenSession(() => new T());
+            return OpenSession((d) => new T());
         }
 
         /// <summary>
@@ -143,13 +143,13 @@ namespace Lucene.Net.Linq
         /// </summary>
         public ISession<T> OpenSession<T>(IDocumentMapper<T> documentMapper) where T : new()
         {
-            return OpenSession(() => new T(), documentMapper);
+            return OpenSession((d) => new T(), documentMapper);
         }
 
         /// <summary>
         /// <see cref="OpenSession{T}(Func{T}, IDocumentMapper{T})"/>
         /// </summary>
-        public ISession<T> OpenSession<T>(Func<T> factory)
+        public ISession<T> OpenSession<T>(Func<Document, T> factory)
         {
             return OpenSession(factory, new ReflectionDocumentMapper<T>(version, externalAnalyzer));
         }
@@ -160,7 +160,7 @@ namespace Lucene.Net.Linq
         /// <param name="factory">Factory delegate that creates new instances of <typeparamref name="T"/></param>
         /// <param name="documentMapper">Mapper that will convert documents to objects and vice versa.</param>
         /// <typeparam name="T">The type of object that will be mapped to <c cref="Document"/>.</typeparam>
-        public ISession<T> OpenSession<T>(Func<T> factory, IDocumentMapper<T> documentMapper)
+        public ISession<T> OpenSession<T>(Func<Document, T> factory, IDocumentMapper<T> documentMapper)
         {
             perFieldAnalyzer.Merge(documentMapper.Analyzer);
 
@@ -176,7 +176,7 @@ namespace Lucene.Net.Linq
         /// </summary>
         public void RegisterCacheWarmingCallback<T>(Action<IQueryable<T>> callback) where T : new()
         {
-            RegisterCacheWarmingCallback(callback, () => new T());
+            RegisterCacheWarmingCallback(callback, (d) => new T());
         }
 
         /// <summary>
@@ -184,13 +184,13 @@ namespace Lucene.Net.Linq
         /// </summary>
         public void RegisterCacheWarmingCallback<T>(Action<IQueryable<T>> callback, IDocumentMapper<T> documentMapper) where T : new()
         {
-            RegisterCacheWarmingCallback(callback, () => new T(), documentMapper);
+            RegisterCacheWarmingCallback(callback, (d) => new T(), documentMapper);
         }
 
         /// <summary>
         /// <see cref="RegisterCacheWarmingCallback{T}(Action{System.Linq.IQueryable{T}}, Func{T}, IDocumentMapper{T})"/>
         /// </summary>
-        public void RegisterCacheWarmingCallback<T>(Action<IQueryable<T>> callback, Func<T> factory)
+        public void RegisterCacheWarmingCallback<T>(Action<IQueryable<T>> callback, Func<Document, T> factory)
         {
             RegisterCacheWarmingCallback(callback, factory, new ReflectionDocumentMapper<T>(version, null));
         }
@@ -205,7 +205,7 @@ namespace Lucene.Net.Linq
         /// 
         /// If this is the first instance, other threads will block until all callbacks complete.
         /// </summary>
-        public void RegisterCacheWarmingCallback<T>(Action<IQueryable<T>> callback, Func<T> factory, IDocumentMapper<T> documentMapper)
+        public void RegisterCacheWarmingCallback<T>(Action<IQueryable<T>> callback, Func<Document, T> factory, IDocumentMapper<T> documentMapper)
         {
             context.SearcherLoading += (s, e) =>
             {
@@ -283,7 +283,7 @@ namespace Lucene.Net.Linq
             get { return Index.IndexWriter.MaxFieldLength.UNLIMITED; }
         }
 
-        private LuceneQueryable<T> CreateQueryable<T>(Func<T> factory, Context context, IDocumentMapper<T> mapper)
+        private LuceneQueryable<T> CreateQueryable<T>(Func<Document, T> factory, Context context, IDocumentMapper<T> mapper)
         {
             var executor = new LuceneQueryExecutor<T>(context, factory, mapper);
             return new LuceneQueryable<T>(queryParser, executor);

--- a/source/Lucene.Net.Linq/LuceneQueryExecutor.cs
+++ b/source/Lucene.Net.Linq/LuceneQueryExecutor.cs
@@ -18,10 +18,10 @@ namespace Lucene.Net.Linq
 {
     internal class LuceneQueryExecutor<TDocument> : LuceneQueryExecutorBase<TDocument>
     {
-        private readonly Func<TDocument> newItem;
+        private readonly Func<Document, TDocument> newItem;
         private readonly IDocumentMapper<TDocument> mapper;
 
-        public LuceneQueryExecutor(Context context, Func<TDocument> newItem, IDocumentMapper<TDocument> mapper)
+        public LuceneQueryExecutor(Context context, Func<Document, TDocument> newItem, IDocumentMapper<TDocument> mapper)
             : base(context)
         {
             this.newItem = newItem;
@@ -30,7 +30,7 @@ namespace Lucene.Net.Linq
 
         protected override TDocument ConvertDocument(Document doc, IQueryExecutionContext context)
         {
-            var item = newItem();
+            var item = newItem(doc);
             
             mapper.ToObject(doc, context, item);
             
@@ -39,7 +39,7 @@ namespace Lucene.Net.Linq
 
         protected override TDocument ConvertDocumentForCustomBoost(Document doc)
         {
-            var item = newItem();
+            var item = newItem(doc);
 
             mapper.ToObject(doc, new QueryExecutionContext(), item);
 


### PR DESCRIPTION
I want to be able to look up objects without having to instantiate a second copy. To this end I have changed the factory delegate to Func<Document, T>.

I think perhaps this would be better as part of the IDocumentMapper, with T CreateObject(..) rather than void ToObject(...), but given that the factory is separate, the way I have done it is idiomatic with the current design.
