### PR TITLE
Initial Fuzzy support

### DIFF
--- a/source/Lucene.Net.Linq.Tests/Integration/FuzzyTests.cs
+++ b/source/Lucene.Net.Linq.Tests/Integration/FuzzyTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Linq;
+using Lucene.Net.Analysis;
+using NUnit.Framework;
+using Version = System.Version;
+
+namespace Lucene.Net.Linq.Tests.Integration
+{
+    [TestFixture]
+    public class FuzzyTests : IntegrationTestBase
+    {
+        private IQueryable<SampleDocument> documents;
+
+        [SetUp]
+        public void AddDocuments()
+        {
+            AddDocument(new SampleDocument { Name = "banana", Scalar = 3, Flag = true, Version = new Version(100, 0, 0) });
+            AddDocument(new SampleDocument { Name = "orange", Scalar = 1, Flag = false, Version = new Version(20, 0, 0) });
+            AddDocument(new SampleDocument { Name = "strawberry", Scalar = 2, Flag = true, Version = new Version(3, 0, 0) });
+
+            documents = provider.AsQueryable<SampleDocument>();
+        }
+
+        [Test]
+        public void EqualFuzzy()
+        {
+            var result = documents
+                .Where(d =>
+                    (d.Name == "bananna").Fuzzy(0.6f))
+                .FirstOrDefault();
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Name, Is.EqualTo("banana"));
+        }
+
+        [Test]
+        public void MultipleEqualFuzzy()
+        {
+            var result = documents
+                .Where(d =>
+                    (d.Name == "bananna").Fuzzy(0.6f) ||
+                    (d.Name == "strawbery").Fuzzy(0.7f))
+                .ToList()
+                .OrderBy(x => x.Name)
+                .ToList();
+
+            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result[0].Name, Is.EqualTo("banana"));
+            Assert.That(result[1].Name, Is.EqualTo("strawberry"));
+        }
+
+        [Test]
+        public void MultipleEqualFuzzy2()
+        {
+            var result = documents
+                .Where(d =>
+                    (d.Name == "bananna").Fuzzy(0.6f) ||
+                    (d.Name == "strawbery").Fuzzy(0.9f))
+                .ToList()
+                .OrderBy(x => x.Name)
+                .ToList();
+
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result[0].Name, Is.EqualTo("banana"));
+        }
+    }
+}

--- a/source/Lucene.Net.Linq.Tests/Lucene.Net.Linq.Tests.csproj
+++ b/source/Lucene.Net.Linq.Tests/Lucene.Net.Linq.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Fluent\TermVectorModeTests.cs" />
     <Compile Include="Integration\AllowSpecialCharactersTests.cs" />
     <Compile Include="Integration\EnumFieldTests.cs" />
+    <Compile Include="Integration\FuzzyTests.cs" />
     <Compile Include="Integration\IndexBoostTests.cs" />
     <Compile Include="Integration\OrderByDateTimeTests.cs" />
     <Compile Include="Integration\QueryBoostTests.cs" />

--- a/source/Lucene.Net.Linq/Clauses/Expressions/LuceneQueryPredicateExpression.cs
+++ b/source/Lucene.Net.Linq/Clauses/Expressions/LuceneQueryPredicateExpression.cs
@@ -48,6 +48,12 @@ namespace Lucene.Net.Linq.Clauses.Expressions
             set { field.Boost = value; }
         }
 
+        public float? Fuzzy
+        {
+            get;
+            set;
+        }
+
         public QueryType QueryType
         {
             get { return queryType; }

--- a/source/Lucene.Net.Linq/Lucene.Net.Linq.csproj
+++ b/source/Lucene.Net.Linq/Lucene.Net.Linq.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Search\Function\DelegatingCustomScoreQuery.cs" />
     <Compile Include="Transformation\TreeVisitors\AllowSpecialCharactersMethodExpressionTreeVisitor.cs" />
     <Compile Include="Transformation\TreeVisitors\BooleanBinaryToQueryPredicateExpressionTreeVisitor.cs" />
+    <Compile Include="Transformation\TreeVisitors\FuzzyMethodCallTreeVisitor.cs" />
     <Compile Include="Transformation\TreeVisitors\BoostMethodCallTreeVisitor.cs" />
     <Compile Include="Transformation\TreeVisitors\ExternallyProvidedQueryExpressionTreeVisitor.cs" />
     <Compile Include="Transformation\TreeVisitors\LuceneExtensionMethodCallTreeVisitor.cs" />

--- a/source/Lucene.Net.Linq/LuceneMethods.cs
+++ b/source/Lucene.Net.Linq/LuceneMethods.cs
@@ -55,6 +55,11 @@ namespace Lucene.Net.Linq
                                 source.Expression, boostFunction));
         }
 
+        public static bool Fuzzy(this bool predicate, float similarity)
+        {
+            throw new InvalidOperationException(UnreachableCode);
+        }
+
         internal static IQueryable<T> TrackRetrievedDocuments<T>(this IQueryable<T> source, IRetrievedDocumentTracker<T> tracker)
         {
             return source.Provider.CreateQuery<T>(

--- a/source/Lucene.Net.Linq/Transformation/QueryModelTransformer.cs
+++ b/source/Lucene.Net.Linq/Transformation/QueryModelTransformer.cs
@@ -38,7 +38,8 @@ namespace Lucene.Net.Linq.Transformation
                            new BinaryToQueryExpressionTreeVisitor(),
                            new RangeQueryMergeExpressionTreeVisitor(), 
                            new AllowSpecialCharactersMethodExpressionTreeVisitor(),
-                           new BoostMethodCallTreeVisitor(1)
+                           new BoostMethodCallTreeVisitor(1),
+                           new FuzzyMethodCallTreeVisitor()
                        },
                    new ExpressionTreeVisitor[]
                        {

--- a/source/Lucene.Net.Linq/Transformation/TreeVisitors/FuzzyMethodCallTreeVisitor.cs
+++ b/source/Lucene.Net.Linq/Transformation/TreeVisitors/FuzzyMethodCallTreeVisitor.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Lucene.Net.Linq.Clauses.Expressions;
+using Lucene.Net.Linq.Search;
+using Remotion.Linq;
+
+namespace Lucene.Net.Linq.Transformation.TreeVisitors
+{
+    internal class FuzzyMethodCallTreeVisitor : MethodInfoMatchingTreeVisitor
+    {
+        private static readonly MethodInfo FuzzyMethod = ReflectionUtility.GetMethod(() => LuceneMethods.Fuzzy(false, 0f));
+
+        internal FuzzyMethodCallTreeVisitor()
+        {
+            AddMethod(FuzzyMethod);
+        }
+
+        protected override Expression VisitSupportedMethodCallExpression(MethodCallExpression expression)
+        {
+            var query = expression.Arguments[0] as LuceneQueryPredicateExpression;
+
+            if (query == null)
+                throw new NotSupportedException("Fuzzy is only supported after predicate expressions. Example: (x.Field == \"term\").Fuzzy(0.6f)");
+
+            if (query.QueryType != QueryType.Default)
+                throw new NotSupportedException("Fuzzy in only supported with default queries. Example: (x.Field == \"term\")");
+               
+            query.Fuzzy = GetFuzzy(expression);
+
+            return query;
+        }
+
+        private static float GetFuzzy(MethodCallExpression expression)
+        {
+            return (float)((ConstantExpression)expression.Arguments[1]).Value;
+        }
+    }
+}

--- a/source/Lucene.Net.Linq/Translation/TreeVisitors/QueryBuildingExpressionTreeVisitor.cs
+++ b/source/Lucene.Net.Linq/Translation/TreeVisitors/QueryBuildingExpressionTreeVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using Lucene.Net.Linq.Clauses.Expressions;
@@ -142,6 +143,15 @@ namespace Lucene.Net.Linq.Translation.TreeVisitors
                     pattern = "*" + pattern;
                     break;
             }
+
+            if (expression.Fuzzy.HasValue)
+            {
+                pattern += string.Format(
+                    CultureInfo.InvariantCulture, 
+                    "~{0}", 
+                    expression.Fuzzy.Value);
+            }
+
             return pattern;
         }
 


### PR DESCRIPTION
I added initial fuzzy support that seems to work well in simple cases like:

```
provider
    .AsQueryable<Entity>()
    .Where(x => (x.Name == "search term").Fuzzy(0.6f))
    .ToList();

provider
    .AsQueryable<Entity>()
    .Where(x => (x.Name == "search term").Fuzzy(0.6f) || (x.Name == "search term 2").Fuzzy(0.6f))
    .ToList();
```

However it fails in more complex cases like:

```
provider
    .AsQueryable<Entity>()
    .Where(x => (x.Name == "search term" || x.Name == "search term 2").Fuzzy(0.6f))
    .ToList();
```

I would be happy too see such feature in an official release.
