### PR TITLE
Document boost support

### DIFF
--- a/source/Lucene.Net.Linq.Tests/Fluent/DocumentBoostTests.cs
+++ b/source/Lucene.Net.Linq.Tests/Fluent/DocumentBoostTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Lucene.Net.Linq.Mapping;
+using NUnit.Framework;
+
+namespace Lucene.Net.Linq.Tests.Fluent
+{
+    [TestFixture]
+    public class DocumentBoostTests : FluentDocumentMapperTestBase
+    {
+        [Test]
+        public void CaptureDocumentBoost()
+        {
+            map.DocumentBoost(x => x.Boost);
+
+            var mapper = GetMappingInfo<ReflectionDocumentBoostMapper<Sample>>("Boost");
+
+            Assert.That(mapper, Is.Not.Null);
+        }
+    }
+}

--- a/source/Lucene.Net.Linq.Tests/Fluent/FluentDocumentMapperTestBase.cs
+++ b/source/Lucene.Net.Linq.Tests/Fluent/FluentDocumentMapperTestBase.cs
@@ -24,6 +24,8 @@ namespace Lucene.Net.Linq.Tests.Fluent
             public IEnumerable<int> Numbers { get; set; }
 
             public IEnumerable<Uri> Urls { get; set; } 
+
+            public float Boost { get; set; }
         }
 
         public class SampleMap : ClassMap<Sample>

--- a/source/Lucene.Net.Linq.Tests/Integration/DocumentBoostTests.cs
+++ b/source/Lucene.Net.Linq.Tests/Integration/DocumentBoostTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using Lucene.Net.Analysis;
+using Lucene.Net.Linq.Mapping;
+using NUnit.Framework;
+
+namespace Lucene.Net.Linq.Tests.Integration
+{
+    [TestFixture]
+    public class DocumentBoostTests : IntegrationTestBase
+    {
+        public class BoostDocument
+        {
+            [Field]
+            public int Key { get; set; }
+
+            [Field(Analyzer = typeof(KeywordAnalyzer))]
+            public string Title { get; set; }
+
+            [DocumentBoost]
+            public float Boost { get; set; }
+
+            [QueryScore]
+            public float Score { get; set; }
+        }
+
+        [Test]
+        public void DocumentBoost()
+        {
+            AddDocument(new BoostDocument { Key = 1, Title = "foo", Boost = 1f });
+            AddDocument(new BoostDocument { Key = 2, Title = "foo", Boost = 2f });
+
+            var result = from doc in provider.AsQueryable<BoostDocument>()
+                         where doc.Title == "foo"
+                         select doc;
+
+            Assert.That(result.First().Key, Is.EqualTo(2));
+            Assert.That(result.OrderByDescending(doc => doc.Score()).First().Key, Is.EqualTo(1));
+        }
+    }
+}

--- a/source/Lucene.Net.Linq.Tests/Lucene.Net.Linq.Tests.csproj
+++ b/source/Lucene.Net.Linq.Tests/Lucene.Net.Linq.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="FakeFieldMappingInfo.cs" />
     <Compile Include="Fluent\AnalyzerTests.cs" />
     <Compile Include="Fluent\ConverterTests.cs" />
+    <Compile Include="Fluent\DocumentBoostTests.cs" />
     <Compile Include="Fluent\DocumentKeyTests.cs" />
     <Compile Include="Fluent\FluentDocumentMapperTestBase.cs" />
     <Compile Include="Fluent\PropertyTests.cs" />
@@ -111,6 +112,7 @@
     <Compile Include="Integration\AllowSpecialCharactersTests.cs" />
     <Compile Include="Integration\EnumFieldTests.cs" />
     <Compile Include="Integration\FuzzyTests.cs" />
+    <Compile Include="Integration\DocumentBoostTests.cs" />
     <Compile Include="Integration\IndexBoostTests.cs" />
     <Compile Include="Integration\OrderByDateTimeTests.cs" />
     <Compile Include="Integration\QueryBoostTests.cs" />
@@ -122,6 +124,7 @@
     <Compile Include="Integration\StatisticTests.cs" />
     <Compile Include="LuceneQueryExecutorTests.cs" />
     <Compile Include="Mapping\FieldMappingInfoBuilderSortFieldTests.cs" />
+    <Compile Include="Mapping\ReflectionDocumentBoostMapperTests.cs" />
     <Compile Include="ReadOnlyLuceneDataProviderTests.cs" />
     <Compile Include="Samples\AttributeConfiguration.cs" />
     <Compile Include="Integration\ScalarTests.cs" />
@@ -187,6 +190,9 @@
       <Project>{77AD18CC-93A3-4BC9-9F31-2C16D873F088}</Project>
       <Name>Lucene.Net.Linq</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/source/Lucene.Net.Linq.Tests/Mapping/ReflectionDocumentBoostMapperTests.cs
+++ b/source/Lucene.Net.Linq.Tests/Mapping/ReflectionDocumentBoostMapperTests.cs
@@ -1,0 +1,40 @@
+﻿using Lucene.Net.Documents;
+using Lucene.Net.Linq.Mapping;
+using Lucene.Net.Search;
+using NUnit.Framework;
+
+namespace Lucene.Net.Linq.Tests.Mapping
+{
+    [TestFixture]
+    public class ReflectionDocumentBoostMapperTests
+    {
+        private ReflectionDocumentBoostMapper<Sample> mapper;
+
+        private Document document;
+        private Sample sample;
+
+        public class Sample
+        {
+            [DocumentBoost]
+            public float Boost { get; set; }
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            document = new Document();
+            sample = new Sample();
+        }
+
+        [Test]
+        public void CopyToDocument()
+        {
+            mapper = new ReflectionDocumentBoostMapper<Sample>(typeof(Sample).GetProperty("Boost"));
+            sample.Boost = 2f;
+
+            mapper.CopyToDocument(sample, document);
+
+            Assert.That(document.Boost, Is.EqualTo(2f));
+        }
+    }
+}

--- a/source/Lucene.Net.Linq.Tests/Samples/AttributeConfiguration.cs
+++ b/source/Lucene.Net.Linq.Tests/Samples/AttributeConfiguration.cs
@@ -46,6 +46,9 @@ namespace Sample
         // Add IgnoreFieldAttribute to properties that should not be mapped to/from Document
         [IgnoreField]
         public string IgnoreMe { get; set; }
+
+        [DocumentBoost]
+        public float Boost { get; set; }
     }
 
     [TestFixture]
@@ -60,7 +63,7 @@ namespace Sample
             // add some documents
             using (var session = provider.OpenSession<Article>())
             {
-                session.Add(new Article {Author = "John Doe", BodyText = "some body text", PublishDate = DateTimeOffset.UtcNow});
+                session.Add(new Article {Author = "John Doe", BodyText = "some body text", PublishDate = DateTimeOffset.UtcNow, Boost = 2f});
             }
 
             var articles = provider.AsQueryable<Article>();

--- a/source/Lucene.Net.Linq.Tests/Samples/FluentConfiguration.cs
+++ b/source/Lucene.Net.Linq.Tests/Samples/FluentConfiguration.cs
@@ -25,6 +25,8 @@ namespace Sample
             map.Property(p => p.IconUrl).NotIndexed();
 
             map.Score(p => p.Score);
+
+            map.DocumentBoost(p => p.Boost);
         }
 
         public class Package
@@ -40,6 +42,8 @@ namespace Sample
             public int DownloadCount { get; set; }
 
             public float Score { get; set; }
+
+            public float Boost { get; set; }
         }
     }
 }

--- a/source/Lucene.Net.Linq/Fluent/ClassMap.cs
+++ b/source/Lucene.Net.Linq/Fluent/ClassMap.cs
@@ -20,7 +20,8 @@ namespace Lucene.Net.Linq.Fluent
         private readonly ISet<PropertyMap<T>> properties = new HashSet<PropertyMap<T>>(new PartComparer<T>());
         private readonly IDictionary<string, string> documentKeys = new Dictionary<string, string>();
         private ReflectionScoreMapper<T> scoreMapper;
- 
+        private ReflectionDocumentBoostMapper<T> docBoostMapper;
+
         public ClassMap(Version version)
         {
             this.version = version;
@@ -62,6 +63,16 @@ namespace Lucene.Net.Linq.Fluent
             properties.Add(part);
 
             return part;
+        }
+
+        /// <summary>
+        /// Defines a property that is used to set the document boost.
+        /// </summary>
+        public void DocumentBoost(Expression<Func<T, float>> expression)
+        {
+            var propInfo = GetMemberInfo<PropertyInfo>(expression.Body);
+
+            docBoostMapper = new ReflectionDocumentBoostMapper<T>(propInfo);
         }
 
         /// <summary>
@@ -120,6 +131,11 @@ namespace Lucene.Net.Linq.Fluent
             if (scoreMapper != null)
             {
                 docMapper.AddField(scoreMapper);
+            }
+
+            if (docBoostMapper != null)
+            {
+                docMapper.AddField(docBoostMapper);
             }
             
             return docMapper;

--- a/source/Lucene.Net.Linq/Lucene.Net.Linq.csproj
+++ b/source/Lucene.Net.Linq/Lucene.Net.Linq.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Mapping\IFieldMapper.cs" />
     <Compile Include="Mapping\IFieldMappingInfo.cs" />
     <Compile Include="Mapping\IFieldMappingInfoProvider.cs" />
+    <Compile Include="Mapping\ReflectionDocumentBoostMapper.cs" />
     <Compile Include="Mapping\ReflectionScoreMapper.cs" />
     <Compile Include="Mapping\TermFreqVectorDocumentMapper.cs" />
     <Compile Include="Mapping\TermVectorMode.cs" />

--- a/source/Lucene.Net.Linq/Mapping/FieldAttribute.cs
+++ b/source/Lucene.Net.Linq/Mapping/FieldAttribute.cs
@@ -207,6 +207,15 @@ namespace Lucene.Net.Linq.Mapping
     }
 
     /// <summary>
+    /// When set on a property, the document boost will be set with the property
+    /// value
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class DocumentBoostAttribute : Attribute
+    {
+    }
+
+    /// <summary>
     /// When set on a class, defines a fixed-value key that will always
     /// be used when querying for objects of this type or deleting and
     /// replacing documents with matching keys.

--- a/source/Lucene.Net.Linq/Mapping/FieldMappingInfoBuilder.cs
+++ b/source/Lucene.Net.Linq/Mapping/FieldMappingInfoBuilder.cs
@@ -23,6 +23,13 @@ namespace Lucene.Net.Linq.Mapping
 
         internal static IFieldMapper<T> Build<T>(PropertyInfo p, Version version, Analyzer externalAnalyzer)
         {
+            var boost = p.GetCustomAttribute<DocumentBoostAttribute>(true);
+
+            if (boost != null)
+            {
+                return new ReflectionDocumentBoostMapper<T>(p);
+            }
+
             var score = p.GetCustomAttribute<QueryScoreAttribute>(true);
 
             if (score != null)

--- a/source/Lucene.Net.Linq/Mapping/ReflectionDocumentBoostMapper.cs
+++ b/source/Lucene.Net.Linq/Mapping/ReflectionDocumentBoostMapper.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Reflection;
+using Lucene.Net.Analysis;
+using Lucene.Net.Documents;
+using Lucene.Net.Linq.Search;
+using Lucene.Net.Search;
+
+namespace Lucene.Net.Linq.Mapping
+{
+    internal class ReflectionDocumentBoostMapper<T> : IFieldMapper<T>, IDocumentFieldConverter
+    {
+        private readonly PropertyInfo propertyInfo;
+
+        public ReflectionDocumentBoostMapper(PropertyInfo propertyInfo)
+        {
+            this.propertyInfo = propertyInfo;
+        }
+
+        public object GetFieldValue(Document document)
+        {
+            return document.Boost;
+        }
+
+        public void CopyToDocument(T source, Document target)
+        {
+            target.Boost = (float)GetPropertyValue(source);
+        }
+
+        public void CopyFromDocument(Document source, IQueryExecutionContext context, T target)
+        {
+            var value = GetFieldValue(source);
+
+            propertyInfo.SetValue(target, value, null);
+        }
+
+        public SortField CreateSortField(bool reverse)
+        {
+            throw new NotSupportedException();
+        }
+
+        public string ConvertToQueryExpression(object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public string EscapeSpecialCharacters(string value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Query CreateQuery(string pattern)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Query CreateRangeQuery(object lowerBound, object upperBound, RangeType lowerRange, RangeType upperRange)
+        {
+            throw new NotSupportedException();
+        }
+
+        public object GetPropertyValue(T source)
+        {
+            return propertyInfo.GetValue(source, null);
+        }
+
+        public string PropertyName { get { return propertyInfo.Name; } }
+        public string FieldName { get { return null; } }
+        public Analyzer Analyzer { get { return null; } }
+    }
+}


### PR DESCRIPTION
Added support for document boost.

Included examples for [Fluid API](https://github.com/tamasflamich/Lucene.Net.Linq/blob/master/source/Lucene.Net.Linq.Tests/Samples/FluentConfiguration.cs) and [attributes](https://github.com/tamasflamich/Lucene.Net.Linq/blob/master/source/Lucene.Net.Linq.Tests/Samples/AttributeConfiguration.cs).
