### PR TITLE
PR to resolve issue:  Session.Add overload for new documents #72

### DIFF
--- a/source/Lucene.Net.Linq.Tests/Integration/SessionTests.cs
+++ b/source/Lucene.Net.Linq.Tests/Integration/SessionTests.cs
@@ -165,7 +165,7 @@ namespace Lucene.Net.Linq.Tests.Integration
 
 
         [Test]
-        public void AddWithoutDeleteCanAllowDuplicates() 
+        public void AddKeyConstraintNoneCanAllowDuplicates() 
         {
             var session = provider.OpenSession<SampleDocument>();
 
@@ -173,11 +173,11 @@ namespace Lucene.Net.Linq.Tests.Integration
                 
                 var newItem = new SampleDocument { Key = "a1", Name = "a new a" };
 
-                session.AddWithoutDelete(newItem);
+                session.Add(KeyConstraint.None, newItem);
 
                 session.Commit();
 
-                session.AddWithoutDelete(newItem);
+                session.Add(KeyConstraint.None, newItem);
 
                 session.Commit();
 
@@ -188,7 +188,7 @@ namespace Lucene.Net.Linq.Tests.Integration
 
 
         [Test]
-        public void AddWithoutDeleteMixedWithAddTracksDocumentsProperly() 
+        public void AddKeyConstraintNoneMixedWithAddTracksDocumentsProperly() 
         {
             var session = provider.OpenSession<SampleDocument>();
 
@@ -202,7 +202,7 @@ namespace Lucene.Net.Linq.Tests.Integration
                 var newItemNoDelete = new SampleDocument { Name = "d" };
 
                 session.Add(newItem);
-                session.AddWithoutDelete(newItemNoDelete);
+                session.Add(KeyConstraint.None, newItemNoDelete);
 
                 session.Commit();
 

--- a/source/Lucene.Net.Linq.Tests/LuceneSessionTests.cs
+++ b/source/Lucene.Net.Linq.Tests/LuceneSessionTests.cs
@@ -138,11 +138,11 @@ namespace Lucene.Net.Linq.Tests
 
 
         [Test]
-        public void Commit_Add_Without_Delete_DoesNotDelete() 
+        public void Commit_Add_KeyConstraint_None_DoesNotDelete() 
         {
             var key = new DocumentKey(new Dictionary<IFieldMappingInfo, object> { { new FakeFieldMappingInfo { FieldName = "Id" }, 1 } });
             var record = new Record { Id = "1" };
-            session.AddWithoutDelete(record);
+            session.Add(KeyConstraint.None, record);
 
             mapper.Expect(m => m.ToDocument(Arg<Record>.Is.Same(record), Arg<Document>.Is.NotNull));
             writer.Expect(w => w.AddDocument(Arg<Document>.Is.NotNull));

--- a/source/Lucene.Net.Linq.Tests/LuceneSessionTests.cs
+++ b/source/Lucene.Net.Linq.Tests/LuceneSessionTests.cs
@@ -112,6 +112,49 @@ namespace Lucene.Net.Linq.Tests
             Assert.That(session.ConvertPendingAdditions, Is.Empty, "Commit should clear pending deletions.");
         }
 
+
+        [Test]
+        public void Commit_Add_DeletesAllKeys() 
+        {
+            var key1 = new DocumentKey(new Dictionary<IFieldMappingInfo, object> { { new FakeFieldMappingInfo { FieldName = "Id" }, 1 } });
+            var key2 = new DocumentKey(new Dictionary<IFieldMappingInfo, object> { { new FakeFieldMappingInfo { FieldName = "Id" }, 2 } });
+
+            var records = new[] { 
+                new Record { Id = "1" }, 
+                new Record { Id = "2" } 
+            };
+
+            session.Add(records);
+
+            mapper.Expect(m => m.ToDocument(Arg<Record>.Is.NotNull, Arg<Document>.Is.NotNull));
+            writer.Expect(w => w.DeleteDocuments(new[] { key2.ToQuery(), key1.ToQuery() }));
+            writer.Expect(w => w.AddDocument(Arg<Document>.Is.NotNull));
+            writer.Expect(w => w.Commit());
+            session.Commit();
+            Verify();
+
+            Assert.That(session.ConvertPendingAdditions, Is.Empty, "Commit should clear pending changes.");
+        }
+
+
+        [Test]
+        public void Commit_Add_Without_Delete_DoesNotDelete() 
+        {
+            var key = new DocumentKey(new Dictionary<IFieldMappingInfo, object> { { new FakeFieldMappingInfo { FieldName = "Id" }, 1 } });
+            var record = new Record { Id = "1" };
+            session.AddWithoutDelete(record);
+
+            mapper.Expect(m => m.ToDocument(Arg<Record>.Is.Same(record), Arg<Document>.Is.NotNull));
+            writer.Expect(w => w.AddDocument(Arg<Document>.Is.NotNull));
+            writer.Expect(w => w.Commit());
+
+            session.Commit();
+            writer.AssertWasNotCalled(a => a.DeleteDocuments(Arg<Query[]>.Is.Anything));
+            Verify();
+
+            Assert.That(session.ConvertPendingAdditions, Is.Empty, "Commit should clear pending changes.");
+        }
+		
         [Test]
         public void Commit_Add_ConvertsDocumentAndKeyLate()
         {

--- a/source/Lucene.Net.Linq/ISession.cs
+++ b/source/Lucene.Net.Linq/ISession.cs
@@ -8,6 +8,7 @@ namespace Lucene.Net.Linq
     {
         IQueryable<T> Query();
         void Add(params T[] items);
+        void AddWithoutDelete(params T[] items);
         void Delete(params T[] items);
         void Delete(params Query[] items);
         void DeleteAll();

--- a/source/Lucene.Net.Linq/ISession.cs
+++ b/source/Lucene.Net.Linq/ISession.cs
@@ -8,7 +8,13 @@ namespace Lucene.Net.Linq
     {
         IQueryable<T> Query();
         void Add(params T[] items);
-        void AddWithoutDelete(params T[] items);
+        /// <summary>
+        /// Add items to the index allowing for specific key constraint behavior
+        /// </summary>
+        /// <param name="constraint"><see cref="KeyConstraint.Unique"/> is the default behavior, <see cref="KeyConstraint.None"/> will 
+        /// not perform a delete operation to ensure uniqueness</param>
+        /// <param name="items"></param>
+        void Add(KeyConstraint constraint, params T[] items);
         void Delete(params T[] items);
         void Delete(params Query[] items);
         void DeleteAll();


### PR DESCRIPTION
Added a KeyConstraint overload to the Add operation on the session. Added some XML documentation to make it a little more clear. Also added some tests to verify the changes.
