### PR TITLE
Computed Field

### DIFF
--- a/source/Lucene.Net.Linq.Tests/Lucene.Net.Linq.Tests.csproj
+++ b/source/Lucene.Net.Linq.Tests/Lucene.Net.Linq.Tests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Integration\StatisticTests.cs" />
     <Compile Include="Integration\SubQueryTests.cs" />
     <Compile Include="LuceneQueryExecutorTests.cs" />
+    <Compile Include="Mapping\ComputedReflectionFieldTests.cs" />
     <Compile Include="Mapping\FieldMappingInfoBuilderSortFieldTests.cs" />
     <Compile Include="Mapping\ReflectionDocumentBoostMapperTests.cs" />
     <Compile Include="ReadOnlyLuceneDataProviderTests.cs" />
@@ -149,6 +150,7 @@
     <Compile Include="Mapping\ReflectionFieldMapperTests.cs" />
     <Compile Include="Mapping\ReflectionScoreMapperTests.cs" />
     <Compile Include="Record.cs" />
+    <Compile Include="Samples\ComputedFieldSample.cs" />
     <Compile Include="Samples\DocumentKeys.cs" />
     <Compile Include="Samples\FluentConfiguration.cs" />
     <Compile Include="Samples\MoreLikeThisSample.cs" />

--- a/source/Lucene.Net.Linq.Tests/Mapping/ComputedReflectionFieldTests.cs
+++ b/source/Lucene.Net.Linq.Tests/Mapping/ComputedReflectionFieldTests.cs
@@ -1,0 +1,10 @@
+﻿using NUnit.Framework;
+
+namespace Lucene.Net.Linq.Tests.Mapping
+{
+	[TestFixture]
+	public class ComputedReflectionFieldTests
+	{
+
+	}
+}

--- a/source/Lucene.Net.Linq.Tests/Mapping/ReflectionDocumentMapperTests.cs
+++ b/source/Lucene.Net.Linq.Tests/Mapping/ReflectionDocumentMapperTests.cs
@@ -245,11 +245,6 @@ namespace Lucene.Net.Linq.Tests.Mapping
 				throw new NotImplementedException();
 			}
 
-			public SortField CreateSortField(bool reverse)
-			{
-				throw new NotImplementedException();
-			}
-
 			public string ConvertToQueryExpression(object value)
 			{
 				throw new NotImplementedException();

--- a/source/Lucene.Net.Linq.Tests/Mapping/ReflectionDocumentMapperTests.cs
+++ b/source/Lucene.Net.Linq.Tests/Mapping/ReflectionDocumentMapperTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Lucene.Net.Documents;
 using Lucene.Net.Linq.Mapping;
+using Lucene.Net.Linq.Search;
+using Lucene.Net.Search;
 using NUnit.Framework;
 using LuceneVersion = Lucene.Net.Util.Version;
 
@@ -206,6 +208,9 @@ namespace Lucene.Net.Linq.Tests.Mapping
 
             [QueryScore]
             public decimal Score { get; set; }
+
+			[ComputedField(typeof(FieldComputer))]
+			public string ComputedField { get; set; }
         }
 
         [DocumentKey(FieldName = "Type", Value = "ReflectedDocumentWithKey")]
@@ -223,6 +228,33 @@ namespace Lucene.Net.Linq.Tests.Mapping
             public string Type { get { return "ReflectedDocumentWithReadOnlyKey"; } }
         }
 
+		public class FieldComputer : IComputedField
+		{
+			public object GetFieldValue(Document document)
+			{
+				return document.GetField("Name") + " " + document.GetField("Location");
+			}
+
+			public Query CreateQuery(string pattern)
+			{
+				throw new NotImplementedException();
+			}
+
+			public Query CreateRangeQuery(object lowerBound, object upperBound, RangeType lowerRange, RangeType upperRange)
+			{
+				throw new NotImplementedException();
+			}
+
+			public SortField CreateSortField(bool reverse)
+			{
+				throw new NotImplementedException();
+			}
+
+			public string ConvertToQueryExpression(object value)
+			{
+				throw new NotImplementedException();
+			}
+		}
     }
 
     

--- a/source/Lucene.Net.Linq.Tests/Mapping/ReflectionDocumentMapperTests.cs
+++ b/source/Lucene.Net.Linq.Tests/Mapping/ReflectionDocumentMapperTests.cs
@@ -245,6 +245,11 @@ namespace Lucene.Net.Linq.Tests.Mapping
 				throw new NotImplementedException();
 			}
 
+			public SortField CreateSortField(bool reverse)
+			{
+				throw new NotImplementedException();
+			}
+
 			public string ConvertToQueryExpression(object value)
 			{
 				throw new NotImplementedException();

--- a/source/Lucene.Net.Linq.Tests/Samples/ComputedFieldSample.cs
+++ b/source/Lucene.Net.Linq.Tests/Samples/ComputedFieldSample.cs
@@ -123,7 +123,7 @@ namespace Lucene.Net.Linq.Tests.Samples
 					.Where(x => x.Status == "Active")
 					.ToList();
 
-				Assert.That(results.Count() != 0);
+				Assert.AreNotEqual(0, results.Count);
 				Assert.That(results.All(x => x.Username.StartsWith("Active")));
 			}
 
@@ -135,7 +135,7 @@ namespace Lucene.Net.Linq.Tests.Samples
 					.Where(x => x.Status == "Inactive")
 					.ToList();
 
-				Assert.That(results.Count() != 0);
+				Assert.AreNotEqual(0, results.Count);
 				Assert.That(results.All(x => x.Username.StartsWith("Inactive")));
 			}
 
@@ -147,7 +147,7 @@ namespace Lucene.Net.Linq.Tests.Samples
 					.Where(x => x.Status == "NotAStatus")
 					.ToList();
 
-				Assert.That(!results.Any());
+				Assert.IsFalse(results.Any());
 			}
 
 			[Test]
@@ -167,9 +167,9 @@ namespace Lucene.Net.Linq.Tests.Samples
 					}
 				}
 
-				Assert.IsTrue(changes == 1);
-				Assert.IsTrue(results.First().Status == "Active");
-				Assert.IsTrue(results.Last().Status == "Inactive");
+				Assert.AreEqual(1, changes);
+				Assert.AreEqual("Active", results.First().Status);
+				Assert.AreEqual("Inactive", results.Last().Status);
 			}
 
 			[Test]
@@ -189,9 +189,9 @@ namespace Lucene.Net.Linq.Tests.Samples
 					}
 				}
 
-				Assert.IsTrue(changes == 1);
-				Assert.IsTrue(results.First().Status == "Inactive");
-				Assert.IsTrue(results.Last().Status == "Active");
+				Assert.AreEqual(1, changes);
+				Assert.AreEqual("Inactive", results.First().Status);
+				Assert.AreEqual("Active", results.Last().Status);
 			}
 		}
 

--- a/source/Lucene.Net.Linq.Tests/Samples/ComputedFieldSample.cs
+++ b/source/Lucene.Net.Linq.Tests/Samples/ComputedFieldSample.cs
@@ -137,6 +137,17 @@ namespace Lucene.Net.Linq.Tests.Samples
 				Assert.That(results.Count() != 0);
 				Assert.That(results.All(x => x.Username.StartsWith("Inactive")));
 			}
+
+			[Test]
+			public void NoRecordsShouldBeReturned()
+			{
+				var results = provider
+					.AsQueryable<User>()
+					.Where(x => x.Status == "NotAStatus")
+					.ToList();
+
+				Assert.That(!results.Any());
+			}
 		}
 	}
 }

--- a/source/Lucene.Net.Linq.Tests/Samples/ComputedFieldSample.cs
+++ b/source/Lucene.Net.Linq.Tests/Samples/ComputedFieldSample.cs
@@ -65,11 +65,6 @@ namespace Lucene.Net.Linq.Tests.Samples
 				throw new NotImplementedException();
 			}
 
-			public SortField CreateSortField(bool reverse)
-			{
-				throw new NotImplementedException();
-			}
-
 			public string ConvertToQueryExpression(object value)
 			{
 				return (string)value;

--- a/source/Lucene.Net.Linq.Tests/Samples/ComputedFieldSample.cs
+++ b/source/Lucene.Net.Linq.Tests/Samples/ComputedFieldSample.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Lucene.Net.Linq.Converters;
+using Lucene.Net.Linq.Mapping;
+using Lucene.Net.Linq.Search;
+using Lucene.Net.Search;
+using Lucene.Net.Documents;
+using Lucene.Net.Store;
+using NUnit.Framework;
+using Version = Lucene.Net.Util.Version;
+
+namespace Lucene.Net.Linq.Tests.Samples
+{
+	public class ComputedFieldSample
+	{
+		public class User
+		{
+			[Field("Username", Key = true, Store = StoreMode.Yes)]
+			public string Username { get; set; }
+
+			[ComputedField(typeof(StatusField))]
+			public string Status { get; set; }
+
+			[NumericField("ActiveFrom", Converter = typeof(DateTimeToTicksConverter))]
+			public DateTime ActiveFrom { get; set; }
+
+			[NumericField("ActiveUntil", Converter = typeof(DateTimeToTicksConverter))]
+			public DateTime ActiveUntil { get; set; }
+		}
+
+		public class StatusField : IComputedField
+		{
+			public object GetFieldValue(Document document)
+			{
+				var activeFrom = new DateTime(Convert.ToInt64(document.GetField("ActiveFrom").StringValue));
+				var activeUntil = new DateTime(Convert.ToInt64(document.GetField("ActiveUntil").StringValue));
+
+				return activeFrom <= DateTime.UtcNow && activeUntil >= DateTime.UtcNow
+					? "Active"
+					: "Inactive";
+			}
+
+			public Query CreateQuery(string pattern)
+			{
+				var query = new BooleanQuery();
+
+				if (pattern == "Active")
+				{
+					query.Add(NumericRangeQuery.NewLongRange("ActiveFrom", DateTime.MinValue.Ticks, DateTime.UtcNow.Ticks, true, true), Occur.MUST);
+					query.Add(NumericRangeQuery.NewLongRange("ActiveUntil", DateTime.UtcNow.Ticks, DateTime.MaxValue.Ticks, true, true), Occur.MUST);
+				}
+				else if (pattern == "Inactive")
+				{
+					query.Add(NumericRangeQuery.NewLongRange("ActiveFrom", DateTime.UtcNow.Ticks, DateTime.MaxValue.Ticks, false, true), Occur.SHOULD);
+					query.Add(NumericRangeQuery.NewLongRange("ActiveUntil", DateTime.MinValue.Ticks, DateTime.UtcNow.Ticks, true, false), Occur.SHOULD);
+				}
+
+				return query;
+			}
+
+			public Query CreateRangeQuery(object lowerBound, object upperBound, RangeType lowerRange, RangeType upperRange)
+			{
+				throw new NotImplementedException();
+			}
+
+			public SortField CreateSortField(bool reverse)
+			{
+				throw new NotImplementedException();
+			}
+
+			public string ConvertToQueryExpression(object value)
+			{
+				return (string)value;
+			}
+		}
+
+		[TestFixture]
+		public class ComputedFieldSampleTests
+		{
+			private Directory directory;
+			private LuceneDataProvider provider;
+
+			[SetUp]
+			public void Setup()
+			{
+				directory = new RAMDirectory();
+				provider = new LuceneDataProvider(directory, Version.LUCENE_30);
+
+				using (var session = provider.OpenSession<User>())
+				{
+					session.Add(
+						new User { Username = "ActiveUser1", ActiveFrom = DateTime.MinValue, ActiveUntil = DateTime.MaxValue },
+						new User { Username = "ActiveUser2", ActiveFrom = DateTime.UtcNow.AddDays(-1), ActiveUntil = DateTime.MaxValue },
+						new User { Username = "ActiveUser3", ActiveFrom = DateTime.MinValue, ActiveUntil = DateTime.UtcNow.AddDays(1) },
+						new User { Username = "InactiveUser1", ActiveFrom = DateTime.UtcNow.AddDays(1), ActiveUntil = DateTime.MaxValue },
+						new User { Username = "InactiveUser2", ActiveFrom = DateTime.MinValue, ActiveUntil = DateTime.UtcNow.AddDays(-1) }
+					);
+				}
+			}
+
+			[TearDown]
+			public void Teardown()
+			{
+				if (provider != null)
+				{
+					provider.Dispose();
+				}
+
+				if (directory != null)
+				{
+					directory.Dispose();
+				}
+			}
+
+			[Test]
+			public void OnlyActiveRecordsShouldBeReturned()
+			{
+				var results = provider
+					.AsQueryable<User>()
+					.Where(x => x.Status == "Active")
+					.ToList();
+
+				Assert.That(results.Count() != 0);
+				Assert.That(results.All(x => x.Username.StartsWith("Active")));
+			}
+
+			[Test]
+			public void OnlyInactiveRecordsShouldBeReturned()
+			{
+				var results = provider
+					.AsQueryable<User>()
+					.Where(x => x.Status == "Inactive")
+					.ToList();
+
+				Assert.That(results.Count() != 0);
+				Assert.That(results.All(x => x.Username.StartsWith("Inactive")));
+			}
+		}
+	}
+}

--- a/source/Lucene.Net.Linq/Lucene.Net.Linq.csproj
+++ b/source/Lucene.Net.Linq/Lucene.Net.Linq.csproj
@@ -93,6 +93,8 @@
     <Compile Include="KeyConstraint.cs" />
     <Compile Include="LuceneDataProviderSettings.cs" />
     <Compile Include="LuceneQueryStatistics.cs" />
+    <Compile Include="Mapping\ComputedFieldAttribute.cs" />
+    <Compile Include="Mapping\ComputedFieldMapper.cs" />
     <Compile Include="Mapping\DocumentKey.cs" />
     <Compile Include="Mapping\DocumentKeyFieldMapper.cs" />
     <Compile Include="Mapping\DocumentMapperBase.cs" />

--- a/source/Lucene.Net.Linq/Lucene.Net.Linq.csproj
+++ b/source/Lucene.Net.Linq/Lucene.Net.Linq.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Mapping\DocumentKey.cs" />
     <Compile Include="Mapping\DocumentKeyFieldMapper.cs" />
     <Compile Include="Mapping\DocumentMapperBase.cs" />
+    <Compile Include="Mapping\IComputedField.cs" />
     <Compile Include="Mapping\IDocumentFieldConverter.cs" />
     <Compile Include="Mapping\IDocumentKeyConverter.cs" />
     <Compile Include="Mapping\IDocumentMapper.cs" />

--- a/source/Lucene.Net.Linq/Mapping/ComputedFieldAttribute.cs
+++ b/source/Lucene.Net.Linq/Mapping/ComputedFieldAttribute.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Lucene.Net.Documents;
+
+namespace Lucene.Net.Linq.Mapping
+{
+	/// <summary>
+	/// Maps a property to a <see cref="IComputedField"/> so that the field
+	/// can be calulated into a queryable field without existing on the index.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+	public class ComputedFieldAttribute : Attribute
+	{
+		/// <param name="fieldComputer">a
+		/// A custom <see cref="IComputedField"/> implementation that can convert the property
+		/// to a Lucene.Net query and from a Lucene.Net document.
+		/// </param>
+		public ComputedFieldAttribute(Type fieldComputer)
+		{
+			FieldComputerInstance = (IComputedField)Activator.CreateInstance(fieldComputer);
+		}
+
+		internal IComputedField FieldComputerInstance { get; set; }
+	}
+}

--- a/source/Lucene.Net.Linq/Mapping/ComputedFieldMapper.cs
+++ b/source/Lucene.Net.Linq/Mapping/ComputedFieldMapper.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Linq.Mapping
 		/// <param name="reverse"></param>
 		public SortField CreateSortField(bool reverse)
 		{
-			throw new NotSupportedException(String.Format("Sorting is not supported on computed field '{0}'.", PropertyName));
+			return this.field.CreateSortField(reverse);
 		}
 
 		/// <summary>

--- a/source/Lucene.Net.Linq/Mapping/ComputedFieldMapper.cs
+++ b/source/Lucene.Net.Linq/Mapping/ComputedFieldMapper.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Reflection;
+using Lucene.Net.Analysis;
+using Lucene.Net.Documents;
+using Lucene.Net.Linq.Search;
+using Lucene.Net.QueryParsers;
+using Lucene.Net.Search;
+
+namespace Lucene.Net.Linq.Mapping
+{
+	internal class ComputedFieldMapper<T> : IFieldMapper<T>, IDocumentFieldConverter
+	{
+		private readonly PropertyInfo propertyInfo;
+		private readonly IComputedField field;
+
+		public ComputedFieldMapper(PropertyInfo propertyInfo, IComputedField field)
+		{
+			this.propertyInfo = propertyInfo;
+			this.field = field;
+		}
+
+		/// <summary>
+		/// Name of Lucene field. By default, this
+		/// will be the same as <see cref="PropertyName"/>.
+		/// </summary>
+		public string FieldName
+		{
+			get { return propertyInfo.Name; }
+		}
+
+		/// <summary>
+		/// Property name.
+		/// </summary>
+		public string PropertyName
+		{
+			get { return propertyInfo.Name; }
+		}
+
+		/// <summary>
+		/// In cases of complex types or numeric fields,
+		/// converts a value into a query expression.
+		/// For string fields, simply returns a string
+		/// representation of the value.
+		/// </summary>
+		public string ConvertToQueryExpression(object value)
+		{
+			return this.field.ConvertToQueryExpression(value);
+		}
+
+		/// <summary>
+		/// Esapes special characters in a query pattern
+		/// such as asterisk (*).
+		/// </summary>
+		public string EscapeSpecialCharacters(string value)
+		{
+			return QueryParser.Escape(value ?? string.Empty);
+		}
+
+		/// <summary>
+		/// Creates a query based on the supplied pattern.
+		/// The pattern should be analyzed and parsed
+		/// (typically by using a <see cref="QueryParser"/>)
+		/// to analyze the pattern and create
+		/// <see cref="WildcardQuery"/>, <see cref="PhraseQuery"/>
+		/// or <see cref="TermQuery"/> as needed.
+		/// </summary>
+		public Query CreateQuery(string pattern)
+		{
+			return this.field.CreateQuery(pattern);
+		}
+
+		/// <summary>
+		/// Creates a range query with the provided criteria.
+		/// </summary>
+		public Query CreateRangeQuery(object lowerBound, object upperBound, RangeType lowerRange, RangeType upperRange)
+		{
+			return this.field.CreateRangeQuery(lowerBound, upperBound, lowerRange, upperRange);
+		}
+
+		/// <summary>
+		/// Creates an appropriate SortField instance for the
+		/// underlying Lucene field.
+		/// </summary>
+		/// <param name="reverse"></param>
+		public SortField CreateSortField(bool reverse)
+		{
+			throw new NotSupportedException(String.Format("Sorting is not supported on computed field '{0}'.", PropertyName));
+		}
+
+		/// <summary>
+		/// Retrieve <see cref="Field"/> or other metadata
+		/// from <paramref name="source"/> and <paramref name="context"/>
+		/// and apply to <paramref name="target"/>.
+		/// </summary>
+		public void CopyFromDocument(Document source, IQueryExecutionContext context, T target)
+		{
+			if (!propertyInfo.CanWrite) return;
+
+			var fieldValue = GetFieldValue(source);
+
+			propertyInfo.SetValue(target, fieldValue, null);
+		}
+
+		/// <summary>
+		/// Convert a DefaultSearchProperty or other data on an instance
+		/// of <paramref name="source"/> into a <see cref="Field"/>
+		/// on the <paramref name="target"/>.
+		/// </summary>
+		public void CopyToDocument(T source, Document target)
+		{
+			// NoOp
+		}
+
+		/// <summary>
+		/// Retrieve a value from <paramref name="source"/>
+		/// for the purposes of constructing an <see cref="IDocumentKey"/>
+		/// or comparing instances of <typeparamref name="T"/>
+		/// to detect dirty objects.
+		/// </summary>
+		public object GetPropertyValue(T source)
+		{
+			return propertyInfo.GetValue(source, null);
+		}
+
+		/// <summary>
+		/// Gets the Analyzer to be used for indexing this field
+		/// or parsing queries on this field.
+		/// </summary>
+		public Analyzer Analyzer
+		{
+			get { return null; }
+		}
+
+		/// <summary>
+		/// Gets the index mode for the field.
+		/// </summary>
+		public IndexMode IndexMode
+		{
+			get { return IndexMode.NotIndexed; }
+		}
+
+		/// <summary>
+		/// Retrieve a field from the given document and
+		/// convert it to a value suitable for the given mapping.
+		/// </summary>
+		public object GetFieldValue(Document document)
+		{
+			return this.field.GetFieldValue(document);
+		}
+	}
+}

--- a/source/Lucene.Net.Linq/Mapping/DocumentMapperBase.cs
+++ b/source/Lucene.Net.Linq/Mapping/DocumentMapperBase.cs
@@ -17,7 +17,7 @@ namespace Lucene.Net.Linq.Mapping
         protected PerFieldAnalyzer analyzer;
         protected readonly Version version;
         protected readonly IDictionary<string, IFieldMapper<T>> fieldMap = new Dictionary<string, IFieldMapper<T>>();
-        protected readonly List<IFieldMapper<T>> keyFields = new List<IFieldMapper<T>>();
+		protected readonly List<IFieldMapper<T>> keyFields = new List<IFieldMapper<T>>();
 
         /// <summary>
         /// Constructs an instance that will create an <see cref="Analyzer"/>
@@ -153,7 +153,7 @@ namespace Lucene.Net.Linq.Mapping
             foreach (var field in fieldMap.Values)
             {
                 // IFieldMapper should tell us if the field is transient/non-comparable
-                if (field is ReflectionScoreMapper<T>)
+				if (field is ReflectionScoreMapper<T> || field is ComputedFieldMapper<T>)
                 {
                     continue;
                 }
@@ -210,6 +210,5 @@ namespace Lucene.Net.Linq.Mapping
             AddField(fieldMapper);
             keyFields.Add(fieldMapper);
         }
-
     }
 }

--- a/source/Lucene.Net.Linq/Mapping/FieldMappingInfoBuilder.cs
+++ b/source/Lucene.Net.Linq/Mapping/FieldMappingInfoBuilder.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.ComponentModel;
 using System.Reflection;
 using Lucene.Net.Analysis;
-using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Linq.Analysis;
 using Lucene.Net.Linq.Converters;
 using Lucene.Net.Linq.Util;
@@ -38,7 +37,7 @@ namespace Lucene.Net.Linq.Mapping
             }
 
             var metadata = p.GetCustomAttribute<FieldAttribute>(true);
-            var numericFieldAttribute = p.GetCustomAttribute<NumericFieldAttribute>(true);
+			var numericFieldAttribute = p.GetCustomAttribute<NumericFieldAttribute>(true);
             Type type;
 
             var isCollection = IsCollection(p.PropertyType, out type);
@@ -49,10 +48,10 @@ namespace Lucene.Net.Linq.Mapping
             {
                 mapper = NumericFieldMappingInfoBuilder.BuildNumeric<T>(p, type, numericFieldAttribute);
             }
-            else
-            {
-                mapper = BuildPrimitive<T>(p, type, metadata, version, externalAnalyzer);
-            }
+			else
+			{
+				mapper = BuildPrimitive<T>(p, type, metadata, version, externalAnalyzer);
+			}
 
             return isCollection ? new CollectionReflectionFieldMapper<T>(mapper, type) : mapper;
         }

--- a/source/Lucene.Net.Linq/Mapping/IComputedField.cs
+++ b/source/Lucene.Net.Linq/Mapping/IComputedField.cs
@@ -1,0 +1,42 @@
+using Lucene.Net.Documents;
+using Lucene.Net.Linq.Search;
+using Lucene.Net.QueryParsers;
+using Lucene.Net.Search;
+
+namespace Lucene.Net.Linq.Mapping
+{
+	/// <summary>
+	/// Represents a field that will be computed based on other fields within a document.
+	/// </summary>
+	public interface IComputedField
+	{
+		/// <summary>
+		/// Retrieve a field from the given document and
+		/// convert it to a value suitable for the given mapping.
+		/// </summary>
+		object GetFieldValue(Document document);
+
+		/// <summary>
+		/// Creates a query based on the supplied pattern.
+		/// The pattern should be analyzed and parsed
+		/// (typically by using a <see cref="QueryParser"/>)
+		/// to analyze the pattern and create
+		/// <see cref="WildcardQuery"/>, <see cref="PhraseQuery"/>
+		/// or <see cref="TermQuery"/> as needed.
+		/// </summary>
+		Query CreateQuery(string pattern);
+
+		/// <summary>
+		/// Creates a range query with the provided criteria.
+		/// </summary>
+		Query CreateRangeQuery(object lowerBound, object upperBound, RangeType lowerRange, RangeType upperRange);
+
+		/// <summary>
+		/// In cases of complex types or numeric fields,
+		/// converts a value into a query expression.
+		/// For string fields, simply returns a string
+		/// representation of the value.
+		/// </summary>
+		string ConvertToQueryExpression(object value);
+	}
+}

--- a/source/Lucene.Net.Linq/Mapping/IComputedField.cs
+++ b/source/Lucene.Net.Linq/Mapping/IComputedField.cs
@@ -32,6 +32,12 @@ namespace Lucene.Net.Linq.Mapping
 		Query CreateRangeQuery(object lowerBound, object upperBound, RangeType lowerRange, RangeType upperRange);
 
 		/// <summary>
+		/// Creates an appropriate SortField instance for the underlying Lucene fields.
+		/// </summary>
+		/// <param name="reverse"></param>
+		SortField CreateSortField(bool reverse);
+
+		/// <summary>
 		/// In cases of complex types or numeric fields,
 		/// converts a value into a query expression.
 		/// For string fields, simply returns a string

--- a/source/Lucene.Net.Linq/Mapping/ReflectionDocumentMapper.cs
+++ b/source/Lucene.Net.Linq/Mapping/ReflectionDocumentMapper.cs
@@ -59,14 +59,15 @@ namespace Lucene.Net.Linq.Mapping
                 {
                     continue;
                 }
-                var mappingContext = FieldMappingInfoBuilder.Build<T>(p, version, externalAnalyzer);
-                
-                fieldMap.Add(mappingContext.PropertyName, mappingContext);
+				
+				var computedField = p.GetCustomAttribute<ComputedFieldAttribute>(true);
+				if (computedField != null)
+				{
+					AddField(new ComputedFieldMapper<T>(p, computedField.FieldComputerInstance));
+					continue;
+				}
 
-                if (!string.IsNullOrWhiteSpace(mappingContext.FieldName) && mappingContext.Analyzer != null)
-                {
-                    analyzer.AddAnalyzer(mappingContext.FieldName, mappingContext.Analyzer);
-                }
+				AddField(FieldMappingInfoBuilder.Build<T>(p, version, externalAnalyzer));
             }
         }
 


### PR DESCRIPTION
I am looking for the ability to have a computed field against an index. I have looked through the different classes currently available and it doesn't appear that there is any way to do this currently. I have written two samples to detail the problem and my proposed solution. If there is a better way to handle this, please let me know! :)

**Problem**
This throws a KeyNotFoundException because the Status field was not added to the queryable fields by the ReflectionDocumentMapper.

``` csharp
void Main()
{
    using(var provider = new LuceneDataProvider(new RAMDirectory(), Version.LUCENE_43))
    {
        using(var session = provider.OpenSession<User>())
        {
            session.Add(
                new User() { Username = "ActiveUser1",      ActiveFrom = DateTime.MinValue,             ActiveUntil = DateTime.MaxValue },
                new User() { Username = "ActiveUser2",      ActiveFrom = DateTime.UtcNow.AddDays(-1),   ActiveUntil = DateTime.MaxValue },
                new User() { Username = "ActiveUser3",      ActiveFrom = DateTime.MinValue,             ActiveUntil = DateTime.UtcNow.AddDays(1) },
                new User() { Username = "InactiveUser1",    ActiveFrom = DateTime.UtcNow.AddDays(1),    ActiveUntil = DateTime.MaxValue },
                new User() { Username = "InactiveUser2",    ActiveFrom = DateTime.MinValue,             ActiveUntil = DateTime.UtcNow.AddDays(-1) }
            );
        }

        var users = provider.AsQueryable<User>();

        var activeUsers = users
            .Where (x => x.Status == "Active")
            .Dump();
    }
}

public class User
{
    [Field("Username", Key = true, Store = StoreMode.Yes)]
    public string Username { get; set; }

    [IgnoreField]
    public string Status
    {
        get
        {
            return this.ActiveFrom <= DateTime.UtcNow && this.ActiveUntil >= DateTime.UtcNow
                ? "Active"
                : "Inactive";
        }
    }

    [NumericField("ActiveFrom", Converter = typeof(DateTimeToTicksConverter))]
    public DateTime ActiveFrom { get; set; }

    [NumericField("ActiveUntil", Converter = typeof(DateTimeToTicksConverter))]
    public DateTime ActiveUntil { get; set; }
}
```

**Proposal**
I think that a new type of column should be added to the library to give users the ability to add the functionality of an actual field without the field being indexed. To do this there would need to be an attribute called ComputedField that would reference a class that represents the functionality of that field. This would allow filtering and displaying of the value while not having to actually index the field.

``` csharp
void Main()
{
    using(var provider = new LuceneDataProvider(new RAMDirectory(), Version.LUCENE_43))
    {
        using(var session = provider.OpenSession<User>())
        {
            session.Add(
                new User() { Username = "ActiveUser1",      ActiveFrom = DateTime.MinValue,             ActiveUntil = DateTime.MaxValue },
                new User() { Username = "ActiveUser2",      ActiveFrom = DateTime.UtcNow.AddDays(-1),   ActiveUntil = DateTime.MaxValue },
                new User() { Username = "ActiveUser3",      ActiveFrom = DateTime.MinValue,             ActiveUntil = DateTime.UtcNow.AddDays(1) },
                new User() { Username = "InactiveUser1",    ActiveFrom = DateTime.UtcNow.AddDays(1),    ActiveUntil = DateTime.MaxValue },
                new User() { Username = "InactiveUser2",    ActiveFrom = DateTime.MinValue,             ActiveUntil = DateTime.UtcNow.AddDays(-1) }
            );
        }

        var users = provider.AsQueryable<User>();

        var activeUsers = users
            //.Where (x => x.Status == "Active")
            .Dump();
    }
}

public class User
{
    [Field("Username", Key = true, Store = StoreMode.Yes)]
    public string Username { get; set; }

    [ComputedField(typeof(StatusField))]
    public string Status { get; set; }

    [NumericField("ActiveFrom", Converter = typeof(DateTimeToTicksConverter))]
    public DateTime ActiveFrom { get; set; }

    [NumericField("ActiveUntil", Converter = typeof(DateTimeToTicksConverter))]
    public DateTime ActiveUntil { get; set; }
}

[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
public class ComputedFieldAttribute : System.Attribute
{
    public ComputedFieldAttribute(Type field)
    {
    }
}

public class StatusField : IComputedField<string, User>
{
    public string GetValue(User record)
    {
        return record.ActiveFrom <= DateTime.UtcNow && record.ActiveUntil >= DateTime.UtcNow
            ? "Active"
            : "Inactive";
    }

    public IEnumerable<User> FilterResults(string value, IEnumerable<User> records)
    {       
        return value == "Active"
            ? records.Where(x => x.ActiveFrom <= DateTime.UtcNow && x.ActiveUntil >= DateTime.UtcNow)
            : records.Where(x => x.ActiveFrom > DateTime.UtcNow && x.ActiveUntil < DateTime.UtcNow);
    }
}

public interface IComputedField<TField, TRecord>
{
    TField GetValue(TRecord record);

    IEnumerable<TRecord> FilterResults(TField value, IEnumerable<TRecord> records);
}
```
