### PR TITLE
PR for Fix for #83 Several types of query return no results

### DIFF
--- a/source/Lucene.Net.Linq.Tests/Integration/WhereExtensionTests.cs
+++ b/source/Lucene.Net.Linq.Tests/Integration/WhereExtensionTests.cs
@@ -95,14 +95,194 @@ namespace Lucene.Net.Linq.Tests.Integration
         }
 
         [Test]
+        public void WhereParseQuery_NoDefaultField()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>();
+            var parsed = parser.Parse("1");
+            var result = documents.Where(parsed);
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Key:1"));
+            Assert.That(parser.Field, Is.EqualTo("Key"));
+        }
+
+        [Test]
         public void WhereParseQuery_OverrideDefaultField()
         {
             var parser = provider.CreateQueryParser<SampleDocument>();
-            parser.DefaultSearchProperty = "Id";
+            parser.DefaultSearchProperty = "Name";
+            var parsed = parser.Parse("\"Bills Document\"");
+            var result = documents.Where(parsed);
 
-            var result = documents.Where(parser.Parse("X.Z.1.3"));
-
+            Assert.That(parsed.ToString(), Is.EqualTo("Name:Bills Document"));
+            Assert.That(parser.Field, Is.EqualTo("Name"));
             Assert.That(result.Single().Name, Is.EqualTo("Bills Document"));
+        }
+
+        [Test]
+        public void WhereParseQuery_OverrideDefaultField_Param()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>("Name");
+            var parsed = parser.Parse("\"Bills Document\"");
+            var result = documents.Where(parsed);
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Name:Bills Document"));
+            Assert.That(parser.Field, Is.EqualTo("Name"));
+            Assert.That(result.Single().Name, Is.EqualTo("Bills Document"));
+        }
+
+        [Test(Description = "Test that default search field can be set in the constructor and changed in the property")]
+        public void WhereParseQuery_OverrideDefaultField_Changed()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>("Id");
+            parser.DefaultSearchProperty = "Name";
+            var parsed = parser.Parse("\"Bills Document\"");
+            var result = documents.Where(parsed);
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Name:Bills Document"));
+            Assert.That(parser.Field, Is.EqualTo("Name"));
+            Assert.That(result.Single().Name, Is.EqualTo("Bills Document"));
+        }
+
+        [Test]
+        public void WhereParseQuery_NoDefaultField_Wildcard()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>();
+            parser.AllowLeadingWildcard = true;
+
+            var parsed = parser.Parse("*");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Key:*"));
+            Assert.That(parser.Field, Is.EqualTo("Key"));
+        }
+
+        [Test]
+        public void WhereParseQuery_OverrideDefaultField_Numeric_Wildcard()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>();
+            parser.AllowLeadingWildcard = true;
+            parser.DefaultSearchProperty = "NullableScalar";
+
+            var parsed = parser.Parse("*");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("NullableScalar:*"));
+            Assert.That(parser.Field, Is.EqualTo("NullableScalar"));
+        }
+
+        [Test]
+        public void WhereParseQuery_OverrideDefaultField_Numeric_Wildcard_Param()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>("NullableScalar");
+            parser.AllowLeadingWildcard = true;
+
+            var parsed = parser.Parse("*");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("NullableScalar:*"));
+            Assert.That(parser.Field, Is.EqualTo("NullableScalar"));
+        }
+
+        [Test]
+        public void WhereParseQuery_NoDefaultField_WildcardPrefix()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>();
+            parser.AllowLeadingWildcard = true;
+
+            var parsed = parser.Parse("*ills");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Key:*ills"));
+            Assert.That(parser.Field, Is.EqualTo("Key"));
+        }
+
+        [Test]
+        public void WhereParseQuery_OverrideDefaultField_WildcardPrefix()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>();
+            parser.AllowLeadingWildcard = true;
+            parser.DefaultSearchProperty = "Name";
+
+            var parsed = parser.Parse("*ills");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Name:*ills"));
+            Assert.That(parser.Field, Is.EqualTo("Name"));
+        }
+
+        [Test]
+        public void WhereParseQuery_OverrideDefaultField_WildcardPrefix_Param()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>("Name");
+            parser.AllowLeadingWildcard = true;
+
+            var parsed = parser.Parse("*ills");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Name:*ills"));
+            Assert.That(parser.Field, Is.EqualTo("Name"));
+        }
+
+        [Test]
+        public void WhereParseQuery_NoDefaultField_Numeric_Range()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>();
+
+            var parsed = parser.Parse("[* TO 2]");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Key:[* TO 2]"));
+            Assert.That(parser.Field, Is.EqualTo("Key"));
+        }
+
+        [Test]
+        public void WhereParseQuery_OverrideDefaultField_Numeric_Range()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>();
+            parser.DefaultSearchProperty = "NullableScalar";
+
+            var parsed = parser.Parse("[* TO 2]");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("NullableScalar:[* TO 2]"));
+            Assert.That(parser.Field, Is.EqualTo("NullableScalar"));
+        }
+
+        [Test]
+        public void WhereParseQuery_OverrideDefaultField_Numeric_Range_Param()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>("NullableScalar");
+
+            var parsed = parser.Parse("[* TO 2]");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("NullableScalar:[* TO 2]"));
+            Assert.That(parser.Field, Is.EqualTo("NullableScalar"));
+        }
+
+        [Test]
+        public void WhereParseQuery_NoDefaultField_Fuzzy()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>();
+
+            var parsed = parser.Parse("bills~0.8");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Key:bills~0.8"));
+            Assert.That(parser.Field, Is.EqualTo("Key"));
+        }
+
+        [Test]
+        public void WhereParseQuery_OverrideDefaultField_Fuzzy()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>();
+            parser.DefaultSearchProperty = "Name";
+
+            var parsed = parser.Parse("bills~0.8");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Name:bills~0.8"));
+            Assert.That(parser.Field, Is.EqualTo("Name"));
+        }
+
+        [Test]
+        public void WhereParseQuery_OverrideDefaultField_Fuzzy_Param()
+        {
+            var parser = provider.CreateQueryParser<SampleDocument>("Name");
+
+            var parsed = parser.Parse("bills~0.8");
+
+            Assert.That(parsed.ToString(), Is.EqualTo("Name:bills~0.8"));
+            Assert.That(parser.Field, Is.EqualTo("Name"));
         }
     }
 }

--- a/source/Lucene.Net.Linq/LuceneDataProvider.cs
+++ b/source/Lucene.Net.Linq/LuceneDataProvider.cs
@@ -136,6 +136,24 @@ namespace Lucene.Net.Linq
         }
 
         /// <summary>
+        /// Create a <see cref="QueryParsers.QueryParser"/> suitable for parsing advanced queries
+        /// that cannot not expressed as LINQ (e.g. queries submitted by a user).
+        ///
+        /// After the instance is returned, options such as <see cref="QueryParsers.QueryParser.AllowLeadingWildcard"/>
+        /// and <see cref="QueryParsers.QueryParser.Field"/> can be customized to the clients needs.
+        /// </summary>
+        /// <typeparam name="T">The type of document that queries will be built against.</typeparam>
+        /// <param name="defaultSearchField">The default field for queries that don't specify which field to search.
+        /// For an example query like <c>Lucene OR NuGet</c>, if this argument is set to <c>SearchText</c>,
+        /// it will produce a query like <c>SearchText:Lucene OR SearchText:NuGet</c>.</param>
+        /// <returns></returns>
+        public FieldMappingQueryParser<T> CreateQueryParser<T>(string defaultSearchField)
+        {
+            var mapper = new ReflectionDocumentMapper<T>(version, externalAnalyzer);
+            return new FieldMappingQueryParser<T>(version, defaultSearchField, mapper);
+        }
+
+        /// <summary>
         /// Gets the index format version provided by constructor.
         /// </summary>
         public Version LuceneVersion


### PR DESCRIPTION
- Created overrides for the Lucene query methods - fixes the broken parses for FieldMappingQueryParser
- Added a constructor override to FieldMappingQueryParser to allow injection of a default search field
- Added a method override CreateQueryParser(string defaultField) on LuceneDataProvider
- Obsoleted DefaultSearchProperty
- Obsoleted the FieldMappingQueryParser constructor without a default field

Not sure what approach you'd want to take to resolving the broken queries, this should cover most cases.

I missed a few test cases in my initial PR - somehow skipped over the fact that this issue affects all queries and not just queries where DefaultSearchProperty is set.
