### PR TITLE
Allow custom type converter with collections

### DIFF
--- a/source/Lucene.Net.Linq.Tests/Helpers/JsonTypeConverter.cs
+++ b/source/Lucene.Net.Linq.Tests/Helpers/JsonTypeConverter.cs
@@ -1,0 +1,61 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Lucene.Net.Linq.Tests
+{
+    public class JsonTypeConverter<T> : System.ComponentModel.TypeConverter
+    {
+        private Type _type = typeof (T);
+
+        public static JsonSerializerSettings DefaultSettings { get; set; }
+
+        static JsonTypeConverter ()
+        {
+            DefaultSettings = new JsonSerializerSettings
+            {
+                //DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                Formatting = Formatting.None,
+                MissingMemberHandling = MissingMemberHandling.Ignore,
+                NullValueHandling = NullValueHandling.Ignore,
+                ObjectCreationHandling = ObjectCreationHandling.Replace
+            };
+        }        
+
+        public override bool CanConvertFrom (System.ComponentModel.ITypeDescriptorContext context, Type sourceType)
+        {
+            return true;
+        }
+
+        public override bool CanConvertTo (System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType)
+        {
+            return true;
+        }
+
+        // Overrides the ConvertFrom method of TypeConverter.
+        public override object ConvertFrom (System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            if (value is string)
+            {
+                return Newtonsoft.Json.JsonConvert.DeserializeObject ((string)value, _type, DefaultSettings);
+            }
+            return Newtonsoft.Json.JsonConvert.SerializeObject (value);
+        }
+
+        // Overrides the ConvertTo method of TypeConverter.
+        public override object ConvertTo (System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (value is string)
+            {
+                if (destinationType == typeof (string))
+                    return value;
+                return Newtonsoft.Json.JsonConvert.DeserializeObject ((string)value, destinationType, DefaultSettings);
+            }
+            if (destinationType == typeof (string))
+                return Newtonsoft.Json.JsonConvert.SerializeObject (value, DefaultSettings);
+            return Newtonsoft.Json.JsonConvert.DeserializeObject (Newtonsoft.Json.JsonConvert.SerializeObject (value), destinationType, DefaultSettings);
+        }
+    }
+}

--- a/source/Lucene.Net.Linq.Tests/Lucene.Net.Linq.Tests.csproj
+++ b/source/Lucene.Net.Linq.Tests/Lucene.Net.Linq.Tests.csproj
@@ -70,6 +70,10 @@
     <Reference Include="Lucene.Net.Contrib.SpellChecker">
       <HintPath>..\..\packages\Lucene.Net.Contrib.3.0.3\lib\net40\Lucene.Net.Contrib.SpellChecker.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
@@ -106,6 +110,7 @@
     <Compile Include="Fluent\ScoreTests.cs" />
     <Compile Include="Fluent\StoreTests.cs" />
     <Compile Include="Fluent\TermVectorModeTests.cs" />
+    <Compile Include="Helpers\JsonTypeConverter.cs" />
     <Compile Include="Integration\AllowSpecialCharactersTests.cs" />
     <Compile Include="Integration\EnumerableContainsTests.cs" />
     <Compile Include="Integration\EnumFieldTests.cs" />

--- a/source/Lucene.Net.Linq.Tests/packages.config
+++ b/source/Lucene.Net.Linq.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="Common.Logging" version="2.3.1" targetFramework="net40" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net40" />
   <package id="Lucene.Net.Contrib" version="3.0.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
   <package id="Remotion.Linq" version="1.13.183.0" targetFramework="net40" />
   <package id="RhinoMocks" version="3.6.1" />

--- a/source/Lucene.Net.Linq/Fluent/PropertyMap.cs
+++ b/source/Lucene.Net.Linq/Fluent/PropertyMap.cs
@@ -245,7 +245,7 @@ namespace Lucene.Net.Linq.Fluent
 
             Type type;
 
-            if (FieldMappingInfoBuilder.IsCollection(propInfo.PropertyType, out type))
+            if (converter == null && FieldMappingInfoBuilder.IsCollection(propInfo.PropertyType, out type))
             {
                 return new CollectionReflectionFieldMapper<T>(mapper, type);
             }

--- a/source/Lucene.Net.Linq/Mapping/FieldMappingInfoBuilder.cs
+++ b/source/Lucene.Net.Linq/Mapping/FieldMappingInfoBuilder.cs
@@ -43,6 +43,13 @@ namespace Lucene.Net.Linq.Mapping
 
             var isCollection = IsCollection(p.PropertyType, out type);
 
+            // if a converter is provided, disable collection treatment
+            if (metadata != null && metadata.Converter != null)
+            {
+                type = p.PropertyType;
+                isCollection = false;
+            }
+
             ReflectionFieldMapper<T> mapper;
 
             if (numericFieldAttribute != null)


### PR DESCRIPTION
Only use CollectionReflectionFieldMapper if no custom type converter was provided. 
Since Generic collections are not implemented, this will allow the user to provide his custom converter.

Example:

```
class sample
{
    public List<string> List { get; set; }
    public Dictionary<string, string> Dic { get; set; }
}

var map = new ClassMap<sample>(Lucene.Net.Util.Version.LUCENE_30);
map.Property(i => i.List).ConvertWith(new CustomListConverter());
map.Property(i => i.Dic).ConvertWith(new CustomDictionaryConverter());
```
