### PR TITLE
Review of usage of reflection

### DIFF
--- a/source/Lucene.Net.Linq/Analysis/PerFieldAnalyzer.cs
+++ b/source/Lucene.Net.Linq/Analysis/PerFieldAnalyzer.cs
@@ -13,7 +13,7 @@ namespace Lucene.Net.Linq.Analysis
     public class PerFieldAnalyzer : Analyzer
     {
         private readonly Analyzer defaultAnalyzer;
-        private readonly IDictionary<string, Analyzer> analyzerMap = new Dictionary<string, Analyzer>();
+        private readonly IDictionary<string, Analyzer> analyzerMap = new Dictionary<string, Analyzer>(StringComparer.Ordinal);
         
         /// <summary> Constructs with default analyzer.
         /// 

--- a/source/Lucene.Net.Linq/Fluent/ClassMap.cs
+++ b/source/Lucene.Net.Linq/Fluent/ClassMap.cs
@@ -18,7 +18,7 @@ namespace Lucene.Net.Linq.Fluent
     {
         private readonly Version version;
         private readonly ISet<PropertyMap<T>> properties = new HashSet<PropertyMap<T>>(new PartComparer<T>());
-        private readonly IDictionary<string, string> documentKeys = new Dictionary<string, string>();
+        private readonly IDictionary<string, string> documentKeys = new Dictionary<string, string>(StringComparer.Ordinal);
         private ReflectionScoreMapper<T> scoreMapper;
         private ReflectionDocumentBoostMapper<T> docBoostMapper;
 

--- a/source/Lucene.Net.Linq/Mapping/CollectionReflectionFieldMapper.cs
+++ b/source/Lucene.Net.Linq/Mapping/CollectionReflectionFieldMapper.cs
@@ -24,14 +24,14 @@ namespace Lucene.Net.Linq.Mapping
             }
 
             // TODO: support collections of IList, ISet, etc.
-            propertyInfo.SetValue(target, values.ToArray(elementType), null);
+            propertySetter(target, values.ToArray (elementType));
         }
 
         public override void CopyToDocument(T source, Document target)
         {
             target.RemoveFields(fieldName);
 
-            var value = (IEnumerable)PropertyInfo.GetValue(source, null);
+            var value = (IEnumerable)propertyGetter(source);
 
             if (value == null)
             {

--- a/source/Lucene.Net.Linq/Mapping/DocumentKey.cs
+++ b/source/Lucene.Net.Linq/Mapping/DocumentKey.cs
@@ -45,8 +45,8 @@ namespace Lucene.Net.Linq.Mapping
 
         public DocumentKey(IDictionary<IFieldMappingInfo, object> values)
         {
-            this.values = new SortedDictionary<string, object>(values.ToDictionary(kv => kv.Key.FieldName, kv => kv.Value));
-            this.mappings = new Dictionary<string, IFieldMappingInfo>(values.ToDictionary(kv => kv.Key.FieldName, kv => kv.Key));
+            this.values = new SortedDictionary<string, object>(values.ToDictionary(kv => kv.Key.FieldName, kv => kv.Value, StringComparer.Ordinal), StringComparer.Ordinal);
+            this.mappings = values.ToDictionary(kv => kv.Key.FieldName, kv => kv.Key, StringComparer.Ordinal);
         }
 
         public Query ToQuery()

--- a/source/Lucene.Net.Linq/Mapping/DocumentMapperBase.cs
+++ b/source/Lucene.Net.Linq/Mapping/DocumentMapperBase.cs
@@ -16,7 +16,7 @@ namespace Lucene.Net.Linq.Mapping
         protected readonly Analyzer externalAnalyzer;
         protected PerFieldAnalyzer analyzer;
         protected readonly Version version;
-        protected readonly IDictionary<string, IFieldMapper<T>> fieldMap = new Dictionary<string, IFieldMapper<T>>();
+        protected readonly IDictionary<string, IFieldMapper<T>> fieldMap = new Dictionary<string, IFieldMapper<T>>(StringComparer.Ordinal);
         protected readonly List<IFieldMapper<T>> keyFields = new List<IFieldMapper<T>>();
 
         /// <summary>

--- a/source/Lucene.Net.Linq/Mapping/NumericReflectionFieldMapper.cs
+++ b/source/Lucene.Net.Linq/Mapping/NumericReflectionFieldMapper.cs
@@ -57,7 +57,7 @@ namespace Lucene.Net.Linq.Mapping
 
         public override void CopyToDocument(T source, Document target)
         {
-            var value = propertyInfo.GetValue(source, null);
+            var value = propertyGetter(source);
 
             target.RemoveFields(fieldName);
 

--- a/source/Lucene.Net.Linq/Mapping/ReflectionFieldMapper.cs
+++ b/source/Lucene.Net.Linq/Mapping/ReflectionFieldMapper.cs
@@ -46,9 +46,9 @@ namespace Lucene.Net.Linq.Mapping
         public ReflectionFieldMapper(PropertyInfo propertyInfo, StoreMode store, IndexMode index, TermVectorMode termVector, TypeConverter converter, string fieldName, QueryParser.Operator defaultParserOperator, bool caseSensitive, Analyzer analyzer, float boost, bool nativeSort = false)
         {
             this.propertyInfo = propertyInfo;
-            this.propertyGetter = CreatePropertyGetter(propertyInfo, fieldName);
+            this.propertyGetter = CreatePropertyGetter(propertyInfo);
             if (propertyInfo.CanWrite)
-                this.propertySetter = CreatePropertySetter(propertyInfo, fieldName);
+                this.propertySetter = CreatePropertySetter(propertyInfo);
             this.store = store;
             this.index = index;
             this.termVector = termVector;
@@ -165,7 +165,8 @@ namespace Lucene.Net.Linq.Mapping
 
             var fieldValue = GetFieldValue(source);
 
-            propertySetter(target, fieldValue);
+            if (fieldValue != null)
+                propertySetter(target, fieldValue);
         }
 
         public object GetFieldValue(Document document)


### PR DESCRIPTION
Review to remove the usage of `PropertyInfo.GetValue` and `PropertyInfo.SetValue` in favor of a compiled methods by using Lambda Expression - a much faster way of dealing with reflection to get and set values.
Also use `StringComparer.Ordinal` for dictionary hash function with is faster than the default.
