### PR TITLE
Performance gain from caching of GetProperties

### DIFF
--- a/source/Lucene.Net.Linq/Mapping/ReflectionDocumentMapper.cs
+++ b/source/Lucene.Net.Linq/Mapping/ReflectionDocumentMapper.cs
@@ -20,6 +20,8 @@ namespace Lucene.Net.Linq.Mapping
     /// </summary>
     public class ReflectionDocumentMapper<T> : DocumentMapperBase<T>
     {
+        protected static PropertyInfo[] properties = null;
+
         /// <summary>
         /// Constructs an instance that will create an <see cref="Analyzer"/>
         /// using metadata on public properties on the type <typeparamref name="T"/>.
@@ -44,11 +46,12 @@ namespace Lucene.Net.Linq.Mapping
         private ReflectionDocumentMapper(Version version, Analyzer externalAnalyzer, Type type)
             : base(version, externalAnalyzer)
         {
-            var props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            if (properties == null)
+                properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
-            BuildFieldMap(props);
+            BuildFieldMap(properties);
 
-            BuildKeyFieldMap(type, props);
+            BuildKeyFieldMap(type, properties);
         }
 
         private void BuildFieldMap(IEnumerable<PropertyInfo> props)


### PR DESCRIPTION
There is a performance gain from caching `GetProperties` result. 

Since the type properties are immutable we can safely save it in a static property for `ReflectionDocumentMapper<T>`.

A simple benchmark indicates a  performance gain of 5-10x (depends on the number of properties a class have).

Here is the code that you can open in LinqPad and test it!
https://gist.github.com/khalidsalomao/7f3a6c3f6c514f584d6a

@chriseldredge, when I was review `ReflectionDocumentMapper<T>` I noticed that the GetProperties only return instance properties. What do you think of also supporting its parent public properties by passing the flag `BindingFlags.FlattenHierarchy`?
