### PR TITLE
updated common logging package

### DIFF
--- a/source/Lucene.Net.Linq/Lucene.Net.Linq.csproj
+++ b/source/Lucene.Net.Linq/Lucene.Net.Linq.csproj
@@ -34,9 +34,13 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=2.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Common.Logging.2.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>

--- a/source/Lucene.Net.Linq/packages.config
+++ b/source/Lucene.Net.Linq/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.3.1" targetFramework="net40" />
+  <package id="Common.Logging" version="3.3.1" targetFramework="net40" />
+  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net40" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net40-Client" />
   <package id="Remotion.Linq" version="1.13.183.0" targetFramework="net40-Client" />
   <package id="SharpZipLib" version="0.86.0" />


### PR DESCRIPTION
The library is far behind its dependencies which causes conflicts with newer packages using same libraries.  the update will resolve this isssue